### PR TITLE
Root CodeBook Export Fix

### DIFF
--- a/codeanno-api/src/main/java/de/uhh/lt/codeanno/api/export/CodebookImportExportServiceImpl.java
+++ b/codeanno-api/src/main/java/de/uhh/lt/codeanno/api/export/CodebookImportExportServiceImpl.java
@@ -182,11 +182,14 @@ public class CodebookImportExportServiceImpl
         // create root ExCBs
         for (CodebookNode root : tree.getRootNodes()) {
             ExportedCodebook rootExCB = createExportedCodebook(tree.getCodebook(root), null);
-            // exportedCodebooks.add(rootExCB);
 
-            // create children recursively
-            for (Codebook child : tree.getChildren(tree.getCodebook(root)))
-                createExportedCodebookRecursively(child, rootExCB, exportedCodebooks, tree);
+            List<Codebook> children = tree.getChildren(tree.getCodebook(root));
+            if (children.size() == 0)
+                exportedCodebooks.add(rootExCB);
+            else
+                // create children recursively
+                for (Codebook child : children)
+                    createExportedCodebookRecursively(child, rootExCB, exportedCodebooks, tree);
         }
 
         return exportedCodebooks;


### PR DESCRIPTION


**What's in the PR**
* fixed issue that lead to empty codebook exports if there are only root CBs. see Trello Card #68

**How to test manually**
* create project with only root CBs and export
* delete the CBs from the project
* import the CB from the exported file
* CBs are now restored correctly

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
